### PR TITLE
megvii: hack to mount libmegface_vendor as libmegface

### DIFF
--- a/megvii/Android.bp
+++ b/megvii/Android.bp
@@ -18,6 +18,16 @@ cc_library_shared {
 }
 
 cc_library_shared {
-    name: "libmegface",
+    name: "libmegface_vendor",
+    required: [
+        "libmegface_vendor.rc",
+    ],
+    vendor: true,
+}
+
+prebuilt_etc {
+    name: "libmegface_vendor.rc",
+    src: "libmegface_vendor.rc",
+    sub_dir: "init",
     vendor: true,
 }

--- a/megvii/libmegface_vendor.rc
+++ b/megvii/libmegface_vendor.rc
@@ -1,0 +1,6 @@
+# hack to mount libmegface_vendor as libmegface
+# as we cant build libmegface with faceunlock 
+# as of faceunlock has similar target
+
+on post-fs
+    mount none /vendor/lib64/libmegface_vendor.so /vendor/lib64/libmegface.so bind


### PR DESCRIPTION
* As we can't build libmegface with face unlock since face unlock has similar target.